### PR TITLE
M6: Production Hardening

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"sabacc/db"
 	"sabacc/room"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -27,9 +28,10 @@ func NewHandler(hub *room.Hub, repo *db.Repository, authSvc *auth.AuthService) *
 }
 
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /rooms", h.CreateRoom)
-	mux.HandleFunc("POST /rooms/{code}/join", h.JoinRoom)
-	mux.HandleFunc("POST /rooms/{code}/spectate", h.SpectateRoom)
+	mux.HandleFunc("GET /health", h.Health)
+	mux.HandleFunc("POST /rooms", RateLimitMiddleware(roomCreateLimiter, h.CreateRoom))
+	mux.HandleFunc("POST /rooms/{code}/join", RateLimitMiddleware(joinLimiter, h.JoinRoom))
+	mux.HandleFunc("POST /rooms/{code}/spectate", RateLimitMiddleware(joinLimiter, h.SpectateRoom))
 	mux.HandleFunc("GET /api/rooms", h.ListRooms)
 	mux.HandleFunc("GET /api/games", h.GetGameHistory)
 	mux.HandleFunc("GET /api/profile/{id}", h.GetProfileByID)
@@ -455,6 +457,16 @@ func (h *Handler) DequeuePlayer(w http.ResponseWriter, r *http.Request) {
 
 	h.Hub.Matchmaker().Dequeue(req.PlayerID)
 	w.WriteHeader(http.StatusOK)
+}
+
+// Health returns a simple liveness/readiness check.
+func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status": "ok",
+		"time":   time.Now().UTC().Format(time.RFC3339),
+		"db":     h.Repo != nil,
+	})
 }
 
 func (h *Handler) GetMatchResult(w http.ResponseWriter, r *http.Request) {

--- a/backend/api/ratelimit.go
+++ b/backend/api/ratelimit.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// tokenBucket is a simple token bucket rate limiter for a single key.
+type tokenBucket struct {
+	tokens     float64
+	maxTokens  float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+func newTokenBucket(maxTokens, refillRate float64) *tokenBucket {
+	return &tokenBucket{
+		tokens:     maxTokens,
+		maxTokens:  maxTokens,
+		refillRate: refillRate,
+		lastRefill: time.Now(),
+	}
+}
+
+// Allow returns true if a token is available and consumes it.
+func (b *tokenBucket) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	b.tokens = min(b.maxTokens, b.tokens+elapsed*b.refillRate)
+	b.lastRefill = now
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+func min(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// RateLimiter manages per-key token buckets.
+type RateLimiter struct {
+	buckets    map[string]*tokenBucket
+	mu         sync.RWMutex
+	maxTokens  float64
+	refillRate float64
+	// cleanup
+	lastClean time.Time
+}
+
+func NewRateLimiter(maxTokens, refillRate float64) *RateLimiter {
+	return &RateLimiter{
+		buckets:    map[string]*tokenBucket{},
+		maxTokens:  maxTokens,
+		refillRate: refillRate,
+		lastClean:  time.Now(),
+	}
+}
+
+func (rl *RateLimiter) Allow(key string) bool {
+	rl.mu.RLock()
+	b, ok := rl.buckets[key]
+	rl.mu.RUnlock()
+
+	if !ok {
+		rl.mu.Lock()
+		// Double-check after acquiring write lock
+		if b, ok = rl.buckets[key]; !ok {
+			b = newTokenBucket(rl.maxTokens, rl.refillRate)
+			rl.buckets[key] = b
+		}
+		rl.mu.Unlock()
+	}
+
+	// Periodically evict old buckets (every 10 minutes)
+	if time.Since(rl.lastClean) > 10*time.Minute {
+		go rl.cleanup()
+	}
+
+	return b.Allow()
+}
+
+func (rl *RateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.lastClean = time.Now()
+	// Remove buckets that are full (idle keys)
+	for key, b := range rl.buckets {
+		b.mu.Lock()
+		full := b.tokens >= b.maxTokens
+		b.mu.Unlock()
+		if full {
+			delete(rl.buckets, key)
+		}
+	}
+}
+
+// extractIP returns the client IP from a request, checking X-Forwarded-For first.
+func extractIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP in the list
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+	// Strip port from RemoteAddr
+	addr := r.RemoteAddr
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			return addr[:i]
+		}
+	}
+	return addr
+}
+
+// retryAfterSeconds computes how many seconds until the bucket refills by 1 token.
+func retryAfterSeconds(refillRate float64) string {
+	secs := int(1.0/refillRate) + 1
+	return strconv.Itoa(secs)
+}
+
+// RateLimitMiddleware wraps a handler with IP-based rate limiting.
+func RateLimitMiddleware(rl *RateLimiter, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip := extractIP(r)
+		if !rl.Allow(ip) {
+			w.Header().Set("Retry-After", retryAfterSeconds(rl.refillRate))
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// Preset limiters used by the handler.
+var (
+	// roomCreateLimiter: 5 rooms per minute per IP (5 tokens, refill 5/60 per second)
+	roomCreateLimiter = NewRateLimiter(5, 5.0/60.0)
+	// joinLimiter: 20 join attempts per minute per IP
+	joinLimiter = NewRateLimiter(20, 20.0/60.0)
+)
+
+// RequestIDMiddleware attaches a unique X-Request-ID header to every request and response.
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-ID")
+		if id == "" {
+			id = fmt.Sprintf("%d-%d", time.Now().UnixNano(), rand.Int63())
+		}
+		w.Header().Set("X-Request-ID", id)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"sabacc/api"
@@ -19,27 +19,30 @@ func main() {
 	if databaseURL != "" {
 		conn, err := db.Connect(databaseURL)
 		if err != nil {
-			log.Fatalf("Failed to connect to database: %v", err)
+			slog.Error("Failed to connect to database", "error", err)
+			os.Exit(1)
 		}
 		defer conn.Close()
 
 		if err := db.RunMigrations(conn); err != nil {
-			log.Fatalf("Failed to run migrations: %v", err)
+			slog.Error("Failed to run migrations", "error", err)
+			os.Exit(1)
 		}
 
 		repo = db.NewRepository(conn)
-		log.Println("Database initialized successfully")
+		slog.Info("Database initialized successfully")
 
 		// Auth service requires a database
 		adapter := auth.NewDBAdapter(repo)
 		authSvc = auth.NewAuthService(adapter)
-		log.Println("Auth service initialized")
+		slog.Info("Auth service initialized")
 	} else {
-		log.Println("WARNING: DATABASE_URL not set — running without database persistence or auth")
+		slog.Warn("DATABASE_URL not set — running without database persistence or auth")
 	}
 
 	hub := room.NewHub(repo)
 	go hub.Run()
+	hub.StartCleanup()
 
 	handler := api.NewHandler(hub, repo, authSvc)
 	mux := http.NewServeMux()
@@ -57,7 +60,7 @@ func main() {
 			}
 			staticFS.ServeHTTP(w, r)
 		})
-		log.Println("Serving static files from ./static")
+		slog.Info("Serving static files from ./static")
 	}
 
 	// CORS middleware for local dev
@@ -80,8 +83,9 @@ func main() {
 	}
 
 	addr := fmt.Sprintf(":%s", port)
-	log.Printf("Backend running on %s", addr)
-	if err := http.ListenAndServe(addr, corsMiddleware(mux)); err != nil {
-		log.Fatal(err)
+	slog.Info("Backend running", "addr", addr)
+	if err := http.ListenAndServe(addr, api.RequestIDMiddleware(corsMiddleware(mux))); err != nil {
+		slog.Error("Server failed", "error", err)
+		os.Exit(1)
 	}
 }

--- a/backend/room/cleanup.go
+++ b/backend/room/cleanup.go
@@ -1,0 +1,68 @@
+package room
+
+import (
+	"log/slog"
+	"sabacc/game"
+	"time"
+)
+
+const (
+	// cleanupInterval is how often the cleanup goroutine runs.
+	cleanupInterval = 2 * time.Minute
+	// emptyRoomTimeout: remove a room if all clients disconnected this long ago.
+	emptyRoomTimeout = 5 * time.Minute
+	// idleLobbyTimeout: remove a lobby room with no activity for this long.
+	idleLobbyTimeout = 30 * time.Minute
+)
+
+// StartCleanup starts a background goroutine that periodically removes stale rooms.
+func (h *Hub) StartCleanup() {
+	go func() {
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			h.cleanupStaleRooms()
+		}
+	}()
+}
+
+func (h *Hub) cleanupStaleRooms() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	now := time.Now()
+	removed := 0
+
+	for code, r := range h.rooms {
+		r.mu.RLock()
+		clientCount := len(r.Clients) + len(r.Spectators)
+		lastActive := r.LastActive
+		phase := r.Game.Phase
+		r.mu.RUnlock()
+
+		shouldRemove := false
+
+		if clientCount == 0 && now.Sub(lastActive) > emptyRoomTimeout {
+			// All clients gone for too long
+			shouldRemove = true
+		} else if phase == game.PhaseLobby && now.Sub(lastActive) > idleLobbyTimeout {
+			// Lobby with no activity for 30 minutes
+			shouldRemove = true
+		}
+
+		if shouldRemove {
+			delete(h.rooms, code)
+			removed++
+			slog.Info("cleanup: removed stale room",
+				"code", code,
+				"phase", string(phase),
+				"clients", clientCount,
+				"idle_minutes", int(now.Sub(lastActive).Minutes()),
+			)
+		}
+	}
+
+	if removed > 0 {
+		slog.Info("cleanup: finished", "rooms_removed", removed, "rooms_remaining", len(h.rooms))
+	}
+}

--- a/backend/room/hub.go
+++ b/backend/room/hub.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"sabacc/db"
 	"sabacc/game"
 	"strings"
@@ -68,12 +68,12 @@ func (h *Hub) createMatchedRoom(players []QueueEntry) {
 	}
 	code, err := h.CreateRoom(players[0].PlayerID, players[0].PlayerName, false)
 	if err != nil {
-		log.Printf("matchmaker: failed to create room: %v", err)
+		slog.Error("matchmaker: failed to create room", "error", err)
 		return
 	}
 	for _, p := range players[1:] {
 		if err := h.JoinRoom(code, p.PlayerID, p.PlayerName); err != nil {
-			log.Printf("matchmaker: failed to join player %s: %v", p.PlayerID, err)
+			slog.Error("matchmaker: failed to join player", "playerID", p.PlayerID, "error", err)
 		}
 	}
 	// Store the code so clients can poll for it
@@ -82,7 +82,7 @@ func (h *Hub) createMatchedRoom(players []QueueEntry) {
 		h.matchResults[p.PlayerID] = code
 	}
 	h.mu.Unlock()
-	log.Printf("matchmaker: created room %s with %d players", code, len(players))
+	slog.Info("matchmaker: created room", "code", code, "players", len(players))
 }
 
 func (h *Hub) Run() {
@@ -253,6 +253,8 @@ func (h *Hub) handleMessage(c *Client, data []byte) {
 
 	room.mu.Lock()
 	defer room.mu.Unlock()
+
+	room.LastActive = time.Now()
 
 	var err error
 	switch action.Type {
@@ -517,7 +519,7 @@ func (h *Hub) broadcastStateUnlocked(room *Room) {
 
 		msg, err := json.Marshal(Envelope{Type: "game_state", Payload: view})
 		if err != nil {
-			log.Printf("marshal error: %v", err)
+			slog.Error("marshal error", "error", err)
 			continue
 		}
 		client.Send(msg)
@@ -539,7 +541,7 @@ func (h *Hub) broadcastStateUnlocked(room *Room) {
 	}
 	spectatorMsg, sErr := json.Marshal(Envelope{Type: "game_state", Payload: spectatorView})
 	if sErr != nil {
-		log.Printf("spectator marshal error: %v", sErr)
+		slog.Error("spectator marshal error", "error", sErr)
 	} else {
 		for _, sc := range room.Spectators {
 			sc.Send(spectatorMsg)
@@ -555,7 +557,7 @@ func (h *Hub) persistGameResult(room *Room) {
 	// Create the game record
 	gameID, err := h.repo.SaveGameState(ctx, room.Code, g.Round, string(g.Phase), nil)
 	if err != nil {
-		log.Printf("failed to save game state: %v", err)
+		slog.Error("failed to save game state", "error", err)
 		return
 	}
 
@@ -578,7 +580,7 @@ func (h *Hub) persistGameResult(room *Room) {
 	}
 
 	if err := h.repo.RecordGameResult(ctx, gameID, results); err != nil {
-		log.Printf("failed to record game result: %v", err)
+		slog.Error("failed to record game result", "error", err)
 	}
 }
 

--- a/backend/room/room.go
+++ b/backend/room/room.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"sabacc/game"
 	"sync"
+	"time"
 )
 
 const codeChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
@@ -24,6 +25,7 @@ type Room struct {
 	ResultSaved    bool               // true once game_over results have been persisted
 	IsPublic       bool
 	ChatTimestamps map[string][]int64 // playerID -> recent message unix-ms timestamps
+	LastActive     time.Time          // updated on any client activity; used by cleanup
 	mu             sync.RWMutex
 }
 
@@ -33,6 +35,7 @@ func NewRoom() *Room {
 		Clients:        map[string]*Client{},
 		Spectators:     map[string]*Client{},
 		ChatTimestamps: map[string][]int64{},
+		LastActive:     time.Now(),
 	}
 }
 
@@ -40,24 +43,28 @@ func (r *Room) AddClient(c *Client) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.Clients[c.PlayerID] = c
+	r.LastActive = time.Now()
 }
 
 func (r *Room) RemoveClient(playerID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.Clients, playerID)
+	r.LastActive = time.Now()
 }
 
 func (r *Room) AddSpectator(c *Client) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.Spectators[c.PlayerID] = c
+	r.LastActive = time.Now()
 }
 
 func (r *Room) RemoveSpectator(playerID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.Spectators, playerID)
+	r.LastActive = time.Now()
 }
 
 func (r *Room) Broadcast(msg []byte) {

--- a/loadtest/go.mod
+++ b/loadtest/go.mod
@@ -1,0 +1,5 @@
+module sabacc/loadtest
+
+go 1.25.5
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/loadtest/go.sum
+++ b/loadtest/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/loadtest/main.go
+++ b/loadtest/main.go
@@ -1,0 +1,207 @@
+// loadtest simulates concurrent WebSocket connections and room activity
+// against a running Sabacc backend to measure concurrency limits and latency.
+//
+// Usage:
+//
+//	go run ./loadtest [flags]
+//
+// Flags:
+//
+//	-url      Backend base URL (default: http://localhost:8080)
+//	-rooms    Number of rooms to create (default: 10)
+//	-players  Players per room (default: 2, max 8)
+//	-duration Test duration in seconds (default: 30)
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ── CLI flags ─────────────────────────────────────────────────────────────────
+
+var (
+	baseURL  = flag.String("url", "http://localhost:8080", "backend base URL")
+	numRooms = flag.Int("rooms", 10, "number of rooms to create")
+	perRoom  = flag.Int("players", 2, "players per room (2-8)")
+	duration = flag.Int("duration", 30, "test duration in seconds")
+)
+
+// ── Counters ──────────────────────────────────────────────────────────────────
+
+var (
+	connOK     atomic.Int64
+	connFail   atomic.Int64
+	msgsRecv   atomic.Int64
+	createOK   atomic.Int64
+	createFail atomic.Int64
+	joinOK     atomic.Int64
+	joinFail   atomic.Int64
+	latSum     atomic.Int64 // microseconds
+	latCount   atomic.Int64
+)
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+func post(path string, body any) (map[string]any, error) {
+	b, _ := json.Marshal(body)
+	resp, err := http.Post(*baseURL+path, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+	var result map[string]any
+	_ = json.Unmarshal(raw, &result)
+	return result, nil
+}
+
+// ── Room scenario ─────────────────────────────────────────────────────────────
+
+func runRoom(roomIdx int, stopAt time.Time, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	hostID := fmt.Sprintf("lt-host-%d", roomIdx)
+	hostName := fmt.Sprintf("Host%d", roomIdx)
+
+	// Create room
+	t0 := time.Now()
+	resp, err := post("/rooms", map[string]any{
+		"playerId":   hostID,
+		"playerName": hostName,
+		"isPublic":   false,
+	})
+	if err != nil {
+		createFail.Add(1)
+		slog.Warn("create room failed", "room", roomIdx, "error", err)
+		return
+	}
+	createOK.Add(1)
+	latSum.Add(int64(time.Since(t0).Microseconds()))
+	latCount.Add(1)
+
+	code, _ := resp["code"].(string)
+	if code == "" {
+		createFail.Add(1)
+		return
+	}
+
+	// Join remaining players
+	players := make([]string, 0, *perRoom)
+	players = append(players, hostID)
+
+	for i := 1; i < *perRoom; i++ {
+		pid := fmt.Sprintf("lt-p%d-%d", roomIdx, i)
+		pname := fmt.Sprintf("P%d_%d", roomIdx, i)
+		t1 := time.Now()
+		_, err := post(fmt.Sprintf("/rooms/%s/join", code), map[string]any{
+			"playerId":   pid,
+			"playerName": pname,
+		})
+		if err != nil {
+			joinFail.Add(1)
+		} else {
+			joinOK.Add(1)
+			latSum.Add(int64(time.Since(t1).Microseconds()))
+			latCount.Add(1)
+		}
+		players = append(players, pid)
+	}
+
+	// Connect all players via WebSocket
+	wsBase := strings.Replace(*baseURL, "http://", "ws://", 1)
+	wsBase = strings.Replace(wsBase, "https://", "wss://", 1)
+
+	var wsWg sync.WaitGroup
+	for _, pid := range players {
+		wsWg.Add(1)
+		go func(playerID string) {
+			defer wsWg.Done()
+			connectAndListen(wsBase, code, playerID, stopAt)
+		}(pid)
+	}
+	wsWg.Wait()
+}
+
+func connectAndListen(wsBase, code, playerID string, stopAt time.Time) {
+	u := url.Values{}
+	u.Set("playerId", playerID)
+	u.Set("roomCode", code)
+	wsURL := wsBase + "/ws?" + u.Encode()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		connFail.Add(1)
+		return
+	}
+	defer conn.Close()
+	connOK.Add(1)
+
+	conn.SetReadDeadline(stopAt)
+	for time.Now().Before(stopAt) {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		msgsRecv.Add(1)
+	}
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+func main() {
+	flag.Parse()
+	slog.Info("load test starting",
+		"url", *baseURL,
+		"rooms", *numRooms,
+		"playersPerRoom", *perRoom,
+		"duration", fmt.Sprintf("%ds", *duration),
+	)
+
+	// Verify server is up
+	resp, err := http.Get(*baseURL + "/health")
+	if err != nil || resp.StatusCode != 200 {
+		slog.Error("server not reachable — is the backend running?", "url", *baseURL)
+		return
+	}
+	resp.Body.Close()
+
+	stopAt := time.Now().Add(time.Duration(*duration) * time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < *numRooms; i++ {
+		wg.Add(1)
+		go runRoom(i, stopAt, &wg)
+	}
+	wg.Wait()
+
+	// Print results
+	totalReqs := latCount.Load()
+	var avgLatency float64
+	if totalReqs > 0 {
+		avgLatency = float64(latSum.Load()) / float64(totalReqs) / 1000.0 // ms
+	}
+
+	fmt.Println("\n── Load Test Results ──────────────────────────────")
+	fmt.Printf("Rooms created:       %d ok / %d fail\n", createOK.Load(), createFail.Load())
+	fmt.Printf("Player joins:        %d ok / %d fail\n", joinOK.Load(), joinFail.Load())
+	fmt.Printf("WS connections:      %d ok / %d fail\n", connOK.Load(), connFail.Load())
+	fmt.Printf("Messages received:   %d\n", msgsRecv.Load())
+	fmt.Printf("Avg HTTP latency:    %.2f ms\n", avgLatency)
+	fmt.Println("───────────────────────────────────────────────────")
+}


### PR DESCRIPTION
## Summary

- **#30 Rate limiting** — Token bucket rate limiter (`backend/api/ratelimit.go`): 5 room-creates/min and 20 joins/min per IP, with `X-Request-ID` middleware
- **#31 Room cleanup** — Background goroutine (`backend/room/cleanup.go`) evicts empty rooms after 5 min and idle lobbies after 30 min; `Room.LastActive` is updated on every client action
- **#32 Structured logging + health check** — All `log.Printf`/`log.Fatalf` replaced with `log/slog` key-value structured logging; `GET /health` endpoint returns JSON status + db availability
- **#34 Load test** — `loadtest/` Go tool: simulates N rooms × M concurrent WebSocket players, measures HTTP latency and WS connection success rate
- **#33** — Closed with infrastructure documentation (no code needed; deploy via Caddy + env vars)

Closes #30
Closes #31
Closes #32
Closes #34